### PR TITLE
Zoneinfo checking and service restarting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ Example:
 
 ```
 
+If you have services that must be restarted in order to pick up the
+new timezone, add them to the `timezone_dependent_services` list.
+They will be restarted with the
+[service](http://docs.ansible.com/service_module.html) module.
+
+Example:
+
+```yaml
+
+- hosts: all
+
+  roles:
+    - Stouts.timezone
+
+  vars:
+    timezone_timezone: Europe/Moscow
+    timezone_dependent_services: [rsyslog, apache2, sendmail]
+```
+
 #### License
 
 Licensed under the MIT License. See the LICENSE file for details.
@@ -38,4 +57,3 @@ Licensed under the MIT License. See the LICENSE file for details.
 #### Feedback, bug-reports, requests, ...
 
 Are [welcome](https://github.com/Stouts/Stouts.timezone/issues)!
-

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,7 @@
 
 - name: timezone deb_update
   command: dpkg-reconfigure --frontend noninteractive tzdata
+
+- name: restart dependent services
+  service: name={{ item }} state=restarted
+  with_items: timezone_dependent_services

--- a/tasks/timezone.yml
+++ b/tasks/timezone.yml
@@ -8,6 +8,14 @@
   yum: name=tzdata
   when: ansible_os_family == 'RedHat'
 
+- name: Check for a zoneinfo file
+  stat: path=/usr/share/zoneinfo/{{timezone_timezone}}
+  register: zoneinfo
+
+- name: Alert if zoneinfo is not there.
+  fail: msg="{{timezone_timezone}} is not valid (/usr/share/zoneinfo/{{timezone_timezone}} does not exist)"
+  when: not (zoneinfo.stat.exists is defined and zoneinfo.stat.exists)
+
 - name: Symlink the correct localtime (/etc/localtime)
   file:
     src: /usr/share/zoneinfo/{{timezone_timezone}}
@@ -17,9 +25,11 @@
     owner: root
     group: root
     mode: 0644
+  when: zoneinfo.stat.exists is defined and zoneinfo.stat.exists
   register: timezone_linked
 
 - name: Set timezone
   template: dest=/etc/timezone src=timezone.j2
   notify: timezone deb_update
-  when: ansible_os_family == 'Debian'
+  notify: restart dependent services
+  when: ansible_os_family == 'Debian' and zoneinfo.stat.exists is defined and zoneinfo.stat.exists

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+timezone_dependent_services: []


### PR DESCRIPTION
This adds two features:
1. If the zoneinfo file doesn't exist, trigger a failure.  This guards against typos or otherwise mashing the timezone name.
2. If the timezone changes, restart any services that should pick up the new timezone.  Syslog is a particularly important one.  This depends on the user setting the dependent services variable to a list of services that should be restarted.
