### PR TITLE
Fix duplicate dict key (notify)

### DIFF
--- a/tasks/timezone.yml
+++ b/tasks/timezone.yml
@@ -30,6 +30,7 @@
 
 - name: Set timezone
   template: dest=/etc/timezone src=timezone.j2
-  notify: timezone deb_update
-  notify: restart dependent services
+  notify:
+    - timezone deb_update
+    - restart dependent services
   when: ansible_os_family == 'Debian' and zoneinfo.stat.exists is defined and zoneinfo.stat.exists


### PR DESCRIPTION
I'm getting the following warnging when using Ansible 2.0:

```
TASK [Stouts.timezone : include] ***********************************************
 [WARNING]: While constructing a mapping from /my/project/ansible/playbooks/roles/Stouts.timezone/tasks/timezone.yml, line 31,
column 3, found a duplicate dict key (notify).  Using last defined value only.

included: /my/project/ansible/playbooks/roles/Stouts.timezone/tasks/timezone.yml for default
```
